### PR TITLE
Handle ./ prefix in file selection

### DIFF
--- a/cmd/vibe/select.go
+++ b/cmd/vibe/select.go
@@ -106,9 +106,6 @@ func ParseMatcher(pattern string) (Matcher, error) {
 		return nil, fmt.Errorf("patterns with '../' are not supported for security reasons")
 	}
 
-	// Strip "./" prefix if present
-	pattern = strings.TrimPrefix(pattern, "./")
-
 	// Check if this is a union pattern with ';' operator (logical OR, highest precedence)
 	if strings.Contains(pattern, ";") {
 		// Split by ';' and trim whitespace from each part

--- a/cmd/vibe/select_test.go
+++ b/cmd/vibe/select_test.go
@@ -84,3 +84,16 @@ func must(m Matcher, err error) Matcher {
 	}
 	return m
 }
+
+func TestParseMatcherDotSlashAnchors(t *testing.T) {
+	paths := []string{
+		"render/foo.go",
+		"cmd/render/bar.go",
+	}
+	m, err := ParseMatcher("./render")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, _ := m.Match(paths)
+	eq(t, got, []string{"render/foo.go"})
+}

--- a/fzf/match.go
+++ b/fzf/match.go
@@ -59,6 +59,11 @@ func NewMatcher(pattern string) (Matcher, error) {
 				t.wordPrefix = true // leading boundary only
 			}
 		}
+		// treat ./ prefix as ^ anchor
+		if strings.HasPrefix(p, "./") {
+			t.anchorHead = true
+			p = p[2:]
+		}
 
 		// --- ^ / $ path anchors ---------------------------------------------------
 		if strings.HasPrefix(p, "^") {

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.24
 	github.com/pkoukk/tiktoken-go v0.1.7
 	github.com/stretchr/testify v1.10.0
+	golang.org/x/term v0.31.0
 )
 
 require (
@@ -52,7 +53,6 @@ require (
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
-	golang.org/x/term v0.31.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect


### PR DESCRIPTION
## Summary
- consider `./` an alias for `^` in `fzf.NewMatcher`
- remove prefix handling from `ParseMatcher`
- test `./render` anchors to path start

## Testing
- `go test ./cmd/vibe -run TestParseMatcherDotSlashAnchors -count=1`
