### PR TITLE
refactor: extract selection package

### DIFF
--- a/cmd/vibe/directory_tree_test.go
+++ b/cmd/vibe/directory_tree_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	setpkg "github.com/hayeah/fork2/internal/set"
 	"os"
 	"path/filepath"
 	"strings"
@@ -121,7 +122,7 @@ func TestDirectoryTree_Filter(t *testing.T) {
 	assert.NoError(err)
 
 	// Create a set of paths for easier assertion
-	pathSet := NewSet[string]()
+	pathSet := setpkg.NewSet[string]()
 	for _, item := range items {
 		pathSet.Add(item.Path)
 	}

--- a/cmd/vibe/filemap.go
+++ b/cmd/vibe/filemap.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"unicode"
-	"unicode/utf8"
 
 	"github.com/hayeah/fork2/internal/metrics"
+	selection "github.com/hayeah/fork2/internal/selection"
 )
 
 // FileMap represents a mapping of file paths to their contents
@@ -18,47 +17,22 @@ type FileMap struct {
 // FileMapWriter handles writing file selections with optional metrics tracking
 type FileMapWriter struct {
 	baseDir string
-	metrics  *metrics.OutputMetrics
+	metrics *metrics.OutputMetrics
 }
 
 // IsBinaryFile checks if content is likely binary by sampling the first 100 runes
 // and checking if they are printable Unicode characters
-func IsBinaryFile(content []byte) bool {
-	// Sample the first 100 runes
-	const sampleSize = 100
-	var nonPrintable int
-	var totalRunes int
-
-	// Convert bytes to runes and check if they're printable
-	for i := 0; i < len(content) && totalRunes < sampleSize; {
-		r, size := utf8.DecodeRune(content[i:])
-		if r == utf8.RuneError {
-			nonPrintable++
-		} else if !unicode.IsPrint(r) && !unicode.IsSpace(r) {
-			nonPrintable++
-		}
-		i += size
-		totalRunes++
-	}
-
-	// If more than 10% of the sampled runes are non-printable, consider it binary
-	threshold := 0.1
-	if totalRunes == 0 {
-		return false // Empty file, not binary
-	}
-	return float64(nonPrintable)/float64(totalRunes) > threshold
-}
 
 // NewWriteFileMap creates a new FileMapWriter with the given base directory and metrics
 func NewWriteFileMap(baseDir string, m *metrics.OutputMetrics) *FileMapWriter {
 	return &FileMapWriter{
 		baseDir: baseDir,
-		metrics:  m,
+		metrics: m,
 	}
 }
 
 // Output writes file selections to the provided writer
-func (w *FileMapWriter) Output(out io.Writer, selections []FileSelection) error {
+func (w *FileMapWriter) Output(out io.Writer, selections []selection.FileSelection) error {
 	for _, selection := range selections {
 		// Skip directories
 		fileInfo, err := os.Stat(selection.Path)

--- a/cmd/vibe/filemap_test.go
+++ b/cmd/vibe/filemap_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	selection "github.com/hayeah/fork2/internal/selection"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,14 +29,14 @@ func TestWriteFileMapDirectory(t *testing.T) {
 	assert.NoError(err)
 
 	// Create file selections including a directory
-	selections := []FileSelection{
+	selections := []selection.FileSelection{
 		{
 			Path:   subDir,
-			Ranges: []LineRange{}, // Not applicable for directory
+			Ranges: []selection.LineRange{}, // Not applicable for directory
 		},
 		{
 			Path:   textFile,
-			Ranges: []LineRange{}, // All content
+			Ranges: []selection.LineRange{}, // All content
 		},
 	}
 

--- a/internal/selection/file_selection.go
+++ b/internal/selection/file_selection.go
@@ -1,4 +1,4 @@
-package main
+package selection
 
 import (
 	"fmt"
@@ -122,7 +122,7 @@ func (fs *FileSelection) extractContents(sortedRanges []LineRange) ([]FileSelect
 	}
 
 	// Check if it's a binary file first (early return)
-	if IsBinaryFile(content) {
+	if isBinaryFile(content) {
 		return []FileSelectionContent{{
 			Path:    fs.Path,
 			Content: "[binary file omitted]",

--- a/internal/selection/file_selection_set.go
+++ b/internal/selection/file_selection_set.go
@@ -1,4 +1,4 @@
-package main
+package selection
 
 import (
 	"sort"

--- a/internal/selection/file_selection_test.go
+++ b/internal/selection/file_selection_test.go
@@ -1,4 +1,4 @@
-package main
+package selection
 
 import (
 	"fmt"

--- a/internal/selection/select.go
+++ b/internal/selection/select.go
@@ -1,7 +1,6 @@
 // Package main provides file selection functionality using various pattern matching techniques.
 //
 // # Pattern Syntax
-//
 // The pattern syntax supports several matching strategies:
 //
 // 1. Fuzzy matching: "foo" matches any path containing "foo"
@@ -13,7 +12,7 @@
 // - Empty pattern: "" matches all paths
 // - "./" prefix is automatically stripped
 // - "../" prefix is rejected for security reasons
-package main
+package selection
 
 import (
 	"bufio"
@@ -21,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/hayeah/fork2/fzf"
+	setpkg "github.com/hayeah/fork2/internal/set"
 )
 
 // Matcher is an interface for matching file paths
@@ -85,7 +85,7 @@ type UnionMatcher struct {
 
 // Match implements the Matcher interface for UnionMatcher
 func (m UnionMatcher) Match(paths []string) ([]string, error) {
-	resultSet := NewSet[string]()
+	resultSet := setpkg.NewSet[string]()
 
 	for _, matcher := range m.Matchers {
 		matches, err := matcher.Match(paths)

--- a/internal/selection/select_test.go
+++ b/internal/selection/select_test.go
@@ -1,6 +1,7 @@
-package main
+package selection_test
 
 import (
+	selectionPkg "github.com/hayeah/fork2/internal/selection"
 	"sort"
 	"testing"
 
@@ -35,27 +36,27 @@ func eq(t *testing.T, got, want []string) {
 func TestUnionMatcher(t *testing.T) {
 	cases := []struct {
 		name  string
-		match Matcher
+		match selectionPkg.Matcher
 		want  []string
 	}{
 		{
 			"foo OR bar",
-			must(ParseMatcher("foo;bar")),
+			must(selectionPkg.ParseMatcher("foo;bar")),
 			[]string{"src/foo.go", "src/foo_test.go", "docs/bar.md"},
 		},
 		{
 			".go OR .md",
-			must(ParseMatcher(".go;.md")),
+			must(selectionPkg.ParseMatcher(".go;.md")),
 			[]string{"src/foo.go", "src/foo_test.go", "docs/bar.md", "internal/baz_test.go", "internal/baz.go", "README.md"},
 		},
 		{
 			"internal OR docs",
-			must(ParseMatcher("internal;docs")),
+			must(selectionPkg.ParseMatcher("internal;docs")),
 			[]string{"docs/bar.md", "internal/baz_test.go", "internal/baz.go"},
 		},
 		{
 			"empty union part",
-			must(ParseMatcher("foo;")),
+			must(selectionPkg.ParseMatcher("foo;")),
 			[]string{"src/foo.go", "src/foo_test.go"},
 		},
 	}
@@ -73,7 +74,7 @@ func TestUnionMatcher(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 // must unwraps matcher creation for brevity in table tests.
-func must(m Matcher, err error) Matcher {
+func must(m selectionPkg.Matcher, err error) selectionPkg.Matcher {
 	if err != nil {
 		panic(err)
 	}
@@ -85,7 +86,7 @@ func TestParseMatcherDotSlashAnchors(t *testing.T) {
 		"render/foo.go",
 		"cmd/render/bar.go",
 	}
-	m, err := ParseMatcher("./render")
+	m, err := selectionPkg.ParseMatcher("./render")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/selection/util.go
+++ b/internal/selection/util.go
@@ -1,0 +1,30 @@
+package selection
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// isBinaryFile checks if content is likely binary by sampling the first 100 runes
+// and checking if they are printable Unicode characters.
+func isBinaryFile(content []byte) bool {
+	const sampleSize = 100
+	var nonPrintable int
+	var totalRunes int
+
+	for i := 0; i < len(content) && totalRunes < sampleSize; {
+		r, size := utf8.DecodeRune(content[i:])
+		if r == utf8.RuneError {
+			nonPrintable++
+		} else if !unicode.IsPrint(r) && !unicode.IsSpace(r) {
+			nonPrintable++
+		}
+		i += size
+		totalRunes++
+	}
+
+	if totalRunes == 0 {
+		return false
+	}
+	return float64(nonPrintable)/float64(totalRunes) > 0.1
+}

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -1,4 +1,4 @@
-package main
+package set
 
 import (
 	"sort"

--- a/internal/set/set_test.go
+++ b/internal/set/set_test.go
@@ -1,6 +1,7 @@
-package main
+package set_test
 
 import (
+	setpkg "github.com/hayeah/fork2/internal/set"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,7 @@ func TestSet_Basic(t *testing.T) {
 	assert := assert.New(t)
 
 	// Create a new set
-	set := NewSet[string]()
+	set := setpkg.NewSet[string]()
 	assert.Equal(0, set.Len(), "New set should be empty")
 
 	// Add elements
@@ -37,7 +38,7 @@ func TestSet_FromSlice(t *testing.T) {
 	assert := assert.New(t)
 
 	slice := []int{1, 2, 3, 2, 1} // Contains duplicates
-	set := NewSetFromSlice(slice)
+	set := setpkg.NewSetFromSlice(slice)
 
 	assert.Equal(3, set.Len(), "Set should have 3 unique elements")
 	assert.True(set.Contains(1), "Set should contain 1")
@@ -48,7 +49,7 @@ func TestSet_FromSlice(t *testing.T) {
 func TestSet_Values(t *testing.T) {
 	assert := assert.New(t)
 
-	set := NewSet[string]()
+	set := setpkg.NewSet[string]()
 	set.AddValues([]string{"apple", "banana", "cherry"})
 
 	values := set.Values()
@@ -61,10 +62,10 @@ func TestSet_Values(t *testing.T) {
 func TestSet_SortedValues(t *testing.T) {
 	assert := assert.New(t)
 
-	set := NewSet[int]()
+	set := setpkg.NewSet[int]()
 	set.AddValues([]int{3, 1, 4, 1, 5, 9, 2, 6, 5})
 
-	sorted := SortedValues(set, func(a, b int) bool {
+	sorted := setpkg.SortedValues(set, func(a, b int) bool {
 		return a < b
 	})
 
@@ -74,8 +75,8 @@ func TestSet_SortedValues(t *testing.T) {
 func TestSet_Union(t *testing.T) {
 	assert := assert.New(t)
 
-	set1 := NewSetFromSlice([]string{"apple", "banana", "cherry"})
-	set2 := NewSetFromSlice([]string{"banana", "cherry", "date"})
+	set1 := setpkg.NewSetFromSlice([]string{"apple", "banana", "cherry"})
+	set2 := setpkg.NewSetFromSlice([]string{"banana", "cherry", "date"})
 
 	union := set1.Union(set2)
 
@@ -89,8 +90,8 @@ func TestSet_Union(t *testing.T) {
 func TestSet_Intersection(t *testing.T) {
 	assert := assert.New(t)
 
-	set1 := NewSetFromSlice([]string{"apple", "banana", "cherry"})
-	set2 := NewSetFromSlice([]string{"banana", "cherry", "date"})
+	set1 := setpkg.NewSetFromSlice([]string{"apple", "banana", "cherry"})
+	set2 := setpkg.NewSetFromSlice([]string{"banana", "cherry", "date"})
 
 	intersection := set1.Intersection(set2)
 
@@ -104,8 +105,8 @@ func TestSet_Intersection(t *testing.T) {
 func TestSet_Difference(t *testing.T) {
 	assert := assert.New(t)
 
-	set1 := NewSetFromSlice([]string{"apple", "banana", "cherry"})
-	set2 := NewSetFromSlice([]string{"banana", "cherry", "date"})
+	set1 := setpkg.NewSetFromSlice([]string{"apple", "banana", "cherry"})
+	set2 := setpkg.NewSetFromSlice([]string{"banana", "cherry", "date"})
 
 	diff := set1.Difference(set2)
 


### PR DESCRIPTION
## Summary
- move file selection helpers to internal/selection
- move generic set to its own util package
- update callers to use new packages
- add binary file detection helper

## Testing
- `go vet ./...`
- `go test ./...`
