### PR TITLE
Refactor pipeline argument handling

### DIFF
--- a/cmd/vibe/out.go
+++ b/cmd/vibe/out.go
@@ -1,19 +1,19 @@
 package main
 
 import (
-        "bytes"
-        "fmt"
-        "io"
-        "log"
-        "net/url"
-        "os"
-        "path/filepath"
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"net/url"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
 	"github.com/atotto/clipboard"
-        "github.com/hayeah/fork2/internal/metrics"
-        "github.com/pkoukk/tiktoken-go"
+	"github.com/hayeah/fork2/internal/metrics"
+	"github.com/pkoukk/tiktoken-go"
 )
 
 // OutCmd contains the arguments for the 'out' subcommand
@@ -29,6 +29,16 @@ type OutCmd struct {
 	Metrics       string   `arg:"-m,--metrics" help:"Write metrics JSON ('-' = stdout)"`
 	Content       []string `arg:"-c,--content,separate" help:"Content source specifications: '-' for stdin, file paths, URLs, or literals (repeatable)"`
 	Instruction   string   `arg:"positional" help:"User instruction or path to instruction file"`
+}
+
+// OutArgs represents the merged options used when running the pipeline.
+type OutArgs struct {
+	Layout        string
+	Select        string
+	SelectDirTree string
+	Instruction   string
+	Content       []string
+	Data          []string
 }
 
 // OutRunner encapsulates the state and behavior for the file picker
@@ -95,42 +105,94 @@ func NewAskRunner(cmdArgs OutCmd, rootPath string) (*OutRunner, error) {
 
 // Run executes the file picking process
 func (r *OutRunner) Run() error {
-        // Gather files/dirs
-        r.DirTree = NewDirectoryTree(r.RootPath)
+	// Gather files/dirs
+	r.DirTree = NewDirectoryTree(r.RootPath)
 
-        var buf bytes.Buffer
-        var dest io.Writer
-        switch {
-        case r.Args.Output == "-":
-                dest = os.Stdout
-        case r.Args.Output != "":
-                file, err := os.Create(r.Args.Output)
-                if err != nil {
-                        return fmt.Errorf("failed to create output file %s: %v", r.Args.Output, err)
-                }
-                defer file.Close()
-                dest = file
-        default:
-                dest = &buf
-        }
+	var buf bytes.Buffer
+	var dest io.Writer
+	switch {
+	case r.Args.Output == "-":
+		dest = os.Stdout
+	case r.Args.Output != "":
+		file, err := os.Create(r.Args.Output)
+		if err != nil {
+			return fmt.Errorf("failed to create output file %s: %v", r.Args.Output, err)
+		}
+		defer file.Close()
+		dest = file
+	default:
+		dest = &buf
+	}
 
-        pipe, err := BuildOutPipeline(r.RootPath, r.Args)
-        if err != nil {
-                return err
-        }
+	pipe, err := BuildOutPipeline(r.RootPath, r.Args)
+	if err != nil {
+		return err
+	}
 
-        if err := pipe.Run(dest, r.Args); err != nil {
-                return err
-        }
+	merged, err := r.buildOutArgs(pipe)
+	if err != nil {
+		return err
+	}
 
-        if r.Args.Output == "" {
-                if err := clipboard.WriteAll(buf.String()); err != nil {
-                        return fmt.Errorf("failed to copy to clipboard: %v", err)
-                }
-                fmt.Fprintln(os.Stderr, "Output copied to clipboard")
-        }
+	if err := pipe.Run(dest, merged); err != nil {
+		return err
+	}
 
-        return nil
+	if r.Args.Output == "" {
+		if err := clipboard.WriteAll(buf.String()); err != nil {
+			return fmt.Errorf("failed to copy to clipboard: %v", err)
+		}
+		fmt.Fprintln(os.Stderr, "Output copied to clipboard")
+	}
+
+	return nil
+}
+
+// buildOutArgs merges command-line flags with template frontmatter to produce
+// the final settings for the pipeline.
+func (r *OutRunner) buildOutArgs(pipe *OutPipeline) (OutArgs, error) {
+	contentPath := r.Args.Instruction
+	if contentPath == "" && r.Args.Select != "" {
+		contentPath = "files"
+	}
+	if strings.HasPrefix(contentPath, "./") {
+		contentPath = strings.TrimPrefix(contentPath, "./")
+	}
+
+	tmpl, err := pipe.Renderer.LoadTemplate(contentPath)
+	if err != nil {
+		return OutArgs{}, err
+	}
+
+	layout := r.Args.Layout
+	if layout == "" {
+		layout = tmpl.FrontMatter.Layout
+	}
+
+	selectPattern := tmpl.FrontMatter.Select
+	if r.Args.Select != "" {
+		selectPattern = r.Args.Select
+	}
+
+	dirTreePattern := tmpl.FrontMatter.Dirtree
+	if r.Args.SelectDirTree != "" {
+		dirTreePattern = r.Args.SelectDirTree
+	}
+
+	if layout == "" && selectPattern != "" {
+		layout = "files"
+	}
+
+	merged := OutArgs{
+		Layout:        layout,
+		Select:        selectPattern,
+		SelectDirTree: dirTreePattern,
+		Instruction:   contentPath,
+		Content:       r.Args.Content,
+		Data:          r.Args.Data,
+	}
+
+	return merged, nil
 }
 
 // parseDataParams parses data parameters from CLI flags into a map

--- a/cmd/vibe/out_pipeline.go
+++ b/cmd/vibe/out_pipeline.go
@@ -1,154 +1,142 @@
 package main
 
 import (
-    "context"
-    "fmt"
-    "io"
-    "strings"
-    "sync"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
 
-    "github.com/hayeah/fork2/internal/metrics"
+	"github.com/hayeah/fork2/internal/metrics"
 )
 
 // OutPipeline groups all services needed by the out command.
 type OutPipeline struct {
-    DT       DirectoryTreeService
-    Renderer RendererService
-    FileMap  FileMapService
-    Metrics  *metrics.OutputMetrics
-    Loader   ContentLoader
+	DT       DirectoryTreeService
+	Renderer RendererService
+	FileMap  FileMapService
+	Metrics  *metrics.OutputMetrics
+	Loader   ContentLoader
 }
 
 // outData implements render.Content and exposes helpers for templates.
 type outData struct {
-    pipeline       *OutPipeline
-    selectPattern  string
-    dirTreePattern string
-    rootPath       string
-    ContentStr     string
-    Data           map[string]string
+	pipeline       *OutPipeline
+	selectPattern  string
+	dirTreePattern string
+	rootPath       string
+	ContentStr     string
+	Data           map[string]string
 
-    fileMapOnce sync.Once
-    fileMap     string
-    fileMapErr  error
+	fileMapOnce sync.Once
+	fileMap     string
+	fileMapErr  error
 
-    treeOnce sync.Once
-    tree     string
-    treeErr  error
+	treeOnce sync.Once
+	tree     string
+	treeErr  error
 
-    promptsOnce sync.Once
-    prompts     string
-    promptsErr  error
+	promptsOnce sync.Once
+	prompts     string
+	promptsErr  error
 }
 
-func (d *outData) Content() string { return d.ContentStr }
+func (d *outData) Content() string     { return d.ContentStr }
 func (d *outData) SetContent(s string) { d.ContentStr = s }
 
 func (d *outData) FileMap() (string, error) {
-    d.fileMapOnce.Do(func() {
-        if d.selectPattern == "" {
-            d.fileMap = ""
-            return
-        }
-        sels, err := d.pipeline.DT.SelectFiles(d.selectPattern)
-        if err != nil {
-            d.fileMapErr = err
-            return
-        }
-        var buf strings.Builder
-        d.fileMapErr = d.pipeline.FileMap.Output(&buf, sels)
-        d.fileMap = buf.String()
-    })
-    return d.fileMap, d.fileMapErr
+	d.fileMapOnce.Do(func() {
+		if d.selectPattern == "" {
+			d.fileMap = ""
+			return
+		}
+		sels, err := d.pipeline.DT.SelectFiles(d.selectPattern)
+		if err != nil {
+			d.fileMapErr = err
+			return
+		}
+		var buf strings.Builder
+		d.fileMapErr = d.pipeline.FileMap.Output(&buf, sels)
+		d.fileMap = buf.String()
+	})
+	return d.fileMap, d.fileMapErr
 }
 
 func (d *outData) RepoDirectoryTree() (string, error) {
-    d.treeOnce.Do(func() {
-        var buf strings.Builder
-        d.treeErr = d.pipeline.DT.GenerateDirectoryTree(&buf, d.dirTreePattern)
-        d.tree = buf.String()
-    })
-    return d.tree, d.treeErr
+	d.treeOnce.Do(func() {
+		var buf strings.Builder
+		d.treeErr = d.pipeline.DT.GenerateDirectoryTree(&buf, d.dirTreePattern)
+		d.tree = buf.String()
+	})
+	return d.tree, d.treeErr
 }
 
 func (d *outData) RepoPrompts() (string, error) {
-    d.promptsOnce.Do(func() {
-        d.prompts, d.promptsErr = loadVibeFiles(d.rootPath)
-    })
-    return d.prompts, d.promptsErr
+	d.promptsOnce.Do(func() {
+		d.prompts, d.promptsErr = loadVibeFiles(d.rootPath)
+	})
+	return d.prompts, d.promptsErr
 }
 
 // Run executes the rendering pipeline using args for configuration.
-func (p *OutPipeline) Run(out io.Writer, args OutCmd) error {
-    dataMap, err := parseDataParams(args.Data)
-    if err != nil {
-        return err
-    }
+func (p *OutPipeline) Run(out io.Writer, args OutArgs) error {
+	dataMap, err := parseDataParams(args.Data)
+	if err != nil {
+		return err
+	}
 
-    content := ""
-    if len(args.Content) > 0 {
-        c, err := p.Loader.LoadSources(context.Background(), args.Content)
-        if err != nil {
-            return fmt.Errorf("failed to load content: %w", err)
-        }
-        content = c
-    }
+	content := ""
+	if len(args.Content) > 0 {
+		c, err := p.Loader.LoadSources(context.Background(), args.Content)
+		if err != nil {
+			return fmt.Errorf("failed to load content: %w", err)
+		}
+		content = c
+	}
 
-    contentPath := args.Instruction
-    if contentPath == "" && args.Select != "" {
-        contentPath = "files"
-    }
-    if strings.HasPrefix(contentPath, "./") {
-        contentPath = strings.TrimPrefix(contentPath, "./")
-    }
+	contentPath := args.Instruction
+	if contentPath == "" && args.Select != "" {
+		contentPath = "files"
+	}
+	if strings.HasPrefix(contentPath, "./") {
+		contentPath = strings.TrimPrefix(contentPath, "./")
+	}
 
-    tmpl, err := p.Renderer.LoadTemplate(contentPath)
-    if err != nil {
-        return fmt.Errorf("error loading content template: %w", err)
-    }
+	tmpl, err := p.Renderer.LoadTemplate(contentPath)
+	if err != nil {
+		return fmt.Errorf("error loading content template: %w", err)
+	}
 
-    if args.Layout != "" {
-        tmpl.FrontMatter.Layout = args.Layout
-    }
+	tmpl.FrontMatter.Layout = args.Layout
+	selectPattern := args.Select
+	dirTreePattern := args.SelectDirTree
 
-    selectPattern := tmpl.FrontMatter.Select
-    if selectPattern == "" {
-        selectPattern = args.Select
-    }
-    dirTreePattern := tmpl.FrontMatter.Dirtree
-    if dirTreePattern == "" {
-        dirTreePattern = args.SelectDirTree
-    }
-    if tmpl.FrontMatter.Layout == "" && selectPattern != "" {
-        tmpl.FrontMatter.Layout = "files"
-    }
+	root := ""
+	if dt, ok := p.DT.(*DirectoryTree); ok {
+		root = dt.RootPath
+	}
 
-    root := ""
-    if dt, ok := p.DT.(*DirectoryTree); ok {
-        root = dt.RootPath
-    }
+	data := &outData{
+		pipeline:       p,
+		selectPattern:  selectPattern,
+		dirTreePattern: dirTreePattern,
+		rootPath:       root,
+		ContentStr:     content,
+		Data:           dataMap,
+	}
 
-    data := &outData{
-        pipeline:       p,
-        selectPattern:  selectPattern,
-        dirTreePattern: dirTreePattern,
-        rootPath:       root,
-        ContentStr:     content,
-        Data:           dataMap,
-    }
+	rendered, err := p.Renderer.RenderTemplate(tmpl, data)
+	if err != nil {
+		return err
+	}
 
-    rendered, err := p.Renderer.RenderTemplate(tmpl, data)
-    if err != nil {
-        return err
-    }
+	if _, err := fmt.Fprint(out, rendered); err != nil {
+		return fmt.Errorf("failed to write output: %v", err)
+	}
 
-    if _, err := fmt.Fprint(out, rendered); err != nil {
-        return fmt.Errorf("failed to write output: %v", err)
-    }
-
-    p.Metrics.Wait()
-    if err := PrintTokenBreakdown(p.Metrics); err != nil {
-        return err
-    }
-    return nil
+	p.Metrics.Wait()
+	if err := PrintTokenBreakdown(p.Metrics); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- create `OutArgs` next to `OutCmd`
- add `buildOutArgs` helper on `OutRunner`
- use helper to merge flags with template frontmatter
- remove duplicate struct from `out_pipeline.go`

## Testing
- `go vet ./...`
- `go test ./...`
