### PR TITLE
Add VSCode tasks install subcommand

### DIFF
--- a/cmd/vibe/install_vscode_tasks.go
+++ b/cmd/vibe/install_vscode_tasks.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	jsonc "github.com/muhammadmuzzammil1998/jsonc"
+)
+
+// InstallVSCodeTasksCmd defines the install:vscode:tasks subcommand.
+type InstallVSCodeTasksCmd struct{}
+
+// InstallVSCodeTasksRunner performs the installation logic.
+type InstallVSCodeTasksRunner struct {
+	RootPath string
+}
+
+func loadJSONC(path string) (map[string]any, error) {
+	data := make(map[string]any)
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return data, nil
+		}
+		return nil, err
+	}
+	cleaned := jsonc.ToJSON(bytes)
+	if err := json.Unmarshal(cleaned, &data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func saveJSON(path string, data map[string]any) error {
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0644)
+}
+
+func deduplicate(items []map[string]any, key string) []map[string]any {
+	seen := make(map[string]bool)
+	var unique []map[string]any
+	for _, item := range items {
+		val, _ := item[key].(string)
+		if val == "" || !seen[val] {
+			if val != "" {
+				seen[val] = true
+			}
+			unique = append(unique, item)
+		}
+	}
+	return unique
+}
+
+func toMapSlice(v any) []map[string]any {
+	arr, _ := v.([]any)
+	res := make([]map[string]any, 0, len(arr))
+	for _, it := range arr {
+		if m, ok := it.(map[string]any); ok {
+			res = append(res, m)
+		}
+	}
+	return res
+}
+
+func mergeJSON(src, dest map[string]any) map[string]any {
+	if dest == nil {
+		dest = map[string]any{}
+	}
+	version, ok := dest["version"]
+	if !ok {
+		if v, ok2 := src["version"]; ok2 {
+			version = v
+		} else {
+			version = "2.0.0"
+		}
+	}
+	dest["version"] = version
+
+	destTasks := toMapSlice(dest["tasks"])
+	srcTasks := toMapSlice(src["tasks"])
+	destInputs := toMapSlice(dest["inputs"])
+	srcInputs := toMapSlice(src["inputs"])
+
+	destTasks = append(destTasks, srcTasks...)
+	destInputs = append(destInputs, srcInputs...)
+
+	dest["tasks"] = deduplicate(destTasks, "label")
+	dest["inputs"] = deduplicate(destInputs, "id")
+	return dest
+}
+
+func previewJSON(data map[string]any) {
+	b, _ := json.MarshalIndent(data, "", "  ")
+	fmt.Printf("\nPreview of merged tasks.json:\n\n%s\n\n", string(b))
+}
+
+func promptConfirmation(msg string) bool {
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Printf("%s (y/n): ", msg)
+		resp, _ := reader.ReadString('\n')
+		resp = strings.TrimSpace(strings.ToLower(resp))
+		if resp == "y" || resp == "yes" {
+			return true
+		}
+		if resp == "n" || resp == "no" {
+			return false
+		}
+		fmt.Println("Please enter 'y' or 'n'.")
+	}
+}
+
+func (r *InstallVSCodeTasksRunner) Run() error {
+	srcPath := filepath.Join(r.RootPath, "vibe.tasks.jsonc")
+	dstPath := filepath.Join(r.RootPath, ".vscode", "tasks.json")
+
+	src, err := loadJSONC(srcPath)
+	if err != nil {
+		return err
+	}
+	if len(src) == 0 {
+		return fmt.Errorf("source file %s not found", srcPath)
+	}
+
+	dst, err := loadJSONC(dstPath)
+	if err != nil {
+		return err
+	}
+
+	merged := mergeJSON(src, dst)
+	previewJSON(merged)
+
+	if !promptConfirmation(fmt.Sprintf("Write merged tasks to %s?", dstPath)) {
+		fmt.Println("Operation cancelled.")
+		return nil
+	}
+
+	if err := saveJSON(dstPath, merged); err != nil {
+		return err
+	}
+
+	fmt.Printf("✅ Successfully merged %s into %s\n", filepath.Base(srcPath), dstPath)
+	return nil
+}

--- a/cmd/vibe/install_vscode_tasks_test.go
+++ b/cmd/vibe/install_vscode_tasks_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInstallVSCodeTasks(t *testing.T) {
+	assert := assert.New(t)
+
+	tempDir := t.TempDir()
+
+	srcContent := `{
+        // comment
+        "version": "2.0.0",
+        "tasks": [
+            {"label": "taskA", "command": "echo A"},
+            {"label": "taskB", "command": "echo B"}
+        ],
+        "inputs": [
+            {"id": "input1", "type": "promptString"}
+        ]
+    }`
+	os.WriteFile(filepath.Join(tempDir, "vibe.tasks.jsonc"), []byte(srcContent), 0644)
+
+	os.Mkdir(filepath.Join(tempDir, ".vscode"), 0755)
+	dstContent := `{
+        "version": "2.0.0",
+        "tasks": [
+            {"label": "taskB", "command": "echo B old"},
+            {"label": "taskC", "command": "echo C"}
+        ]
+    }`
+	os.WriteFile(filepath.Join(tempDir, ".vscode", "tasks.json"), []byte(dstContent), 0644)
+
+	runner := &InstallVSCodeTasksRunner{RootPath: tempDir}
+
+	// Feed confirmation
+	f, err := os.CreateTemp(tempDir, "input")
+	assert.NoError(err)
+	_, err = f.WriteString("y\n")
+	assert.NoError(err)
+	f.Close()
+	inputFile, _ := os.Open(f.Name())
+	oldStdin := os.Stdin
+	os.Stdin = inputFile
+	defer func() { os.Stdin = oldStdin; inputFile.Close() }()
+
+	err = runner.Run()
+	assert.NoError(err)
+
+	data, err := os.ReadFile(filepath.Join(tempDir, ".vscode", "tasks.json"))
+	assert.NoError(err)
+
+	var result map[string]any
+	err = json.Unmarshal(data, &result)
+	assert.NoError(err)
+
+	tasks := result["tasks"].([]any)
+	labels := []string{}
+	for _, v := range tasks {
+		m := v.(map[string]any)
+		labels = append(labels, m["label"].(string))
+	}
+	assert.Equal([]string{"taskB", "taskC", "taskA"}, labels)
+
+	inputs := result["inputs"].([]any)
+	inputIDs := []string{}
+	for _, v := range inputs {
+		m := v.(map[string]any)
+		inputIDs = append(inputIDs, m["id"].(string))
+	}
+	assert.Equal([]string{"input1"}, inputIDs)
+}

--- a/cmd/vibe/main.go
+++ b/cmd/vibe/main.go
@@ -10,9 +10,10 @@ import (
 
 // Args defines the command-line arguments with subcommands
 type Args struct {
-	Out *OutCmd `arg:"subcommand:out" help:"Select files and generate output"`
-	Ls  *LsCmd  `arg:"subcommand:ls" help:"List files matching patterns"`
-	New *NewCmd `arg:"subcommand:new" help:"Create a new prompt/template"`
+	Out  *OutCmd                `arg:"subcommand:out" help:"Select files and generate output"`
+	Ls   *LsCmd                 `arg:"subcommand:ls" help:"List files matching patterns"`
+	New  *NewCmd                `arg:"subcommand:new" help:"Create a new prompt/template"`
+	VSCT *InstallVSCodeTasksCmd `arg:"subcommand:install:vscode:tasks" help:"Merge vibe.tasks.jsonc into .vscode/tasks.json"`
 }
 
 // item represents each file or directory in the listing.
@@ -61,8 +62,11 @@ func (r *Runner) Run() error {
 			return err
 		}
 		return newRunner.Run()
+	case r.Args.VSCT != nil:
+		runner := &InstallVSCodeTasksRunner{RootPath: r.RootPath}
+		return runner.Run()
 	default:
-		return fmt.Errorf("no subcommand specified, use 'out', 'merge', 'ls', or 'new'")
+		return fmt.Errorf("no subcommand specified, use 'out', 'merge', 'ls', 'new', or 'install:vscode:tasks'")
 	}
 }
 
@@ -72,7 +76,7 @@ func main() {
 	parser := arg.MustParse(&args)
 
 	// If no subcommand is specified, show help
-	if args.Out == nil && args.Ls == nil && args.New == nil {
+	if args.Out == nil && args.Ls == nil && args.New == nil && args.VSCT == nil {
 		parser.WriteHelp(os.Stderr)
 		os.Exit(1)
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,10 @@ require (
 	github.com/go-git/go-billy/v5 v5.6.2
 	github.com/go-git/go-git/v5 v5.14.0
 	github.com/google/wire v0.6.0
-	github.com/pkoukk/tiktoken-go v0.1.7
-	github.com/stretchr/testify v1.10.0
-	golang.org/x/term v0.31.0
+        github.com/pkoukk/tiktoken-go v0.1.7
+        github.com/stretchr/testify v1.10.0
+        github.com/muhammadmuzzammil1998/jsonc v0.3.0
+        golang.org/x/term v0.31.0
 )
 
 require (
@@ -31,3 +32,5 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/muhammadmuzzammil1998/jsonc => ./third_party/jsonc

--- a/third_party/jsonc/go.mod
+++ b/third_party/jsonc/go.mod
@@ -1,0 +1,3 @@
+module github.com/muhammadmuzzammil1998/jsonc
+
+go 1.24

--- a/third_party/jsonc/jsonc.go
+++ b/third_party/jsonc/jsonc.go
@@ -1,0 +1,46 @@
+package jsonc
+
+// ToJSON removes JavaScript-style comments from a JSONC byte slice.
+// This is a minimal implementation sufficient for basic cases.
+func ToJSON(data []byte) []byte {
+	out := make([]byte, 0, len(data))
+	inString := false
+	inSingle := false
+	inMulti := false
+	for i := 0; i < len(data); i++ {
+		c := data[i]
+		next := byte(0)
+		if i+1 < len(data) {
+			next = data[i+1]
+		}
+		if inSingle {
+			if c == '\n' {
+				inSingle = false
+				out = append(out, c)
+			}
+			continue
+		}
+		if inMulti {
+			if c == '*' && next == '/' {
+				inMulti = false
+				i++
+			}
+			continue
+		}
+		if !inString && c == '/' && next == '/' {
+			inSingle = true
+			i++
+			continue
+		}
+		if !inString && c == '/' && next == '*' {
+			inMulti = true
+			i++
+			continue
+		}
+		if c == '"' && (i == 0 || data[i-1] != '\\') {
+			inString = !inString
+		}
+		out = append(out, c)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- implement `install:vscode:tasks` subcommand
- merge and deduplicate `vibe.tasks.jsonc` into `.vscode/tasks.json`
- include helper functions and local JSONC parser
- integrate command into CLI
- add corresponding tests

## Testing
- `go build ./...`
- `go test ./...`
