### PR TITLE
Refactor out pipeline config

### DIFF
--- a/cmd/vibe/wire_gen.go
+++ b/cmd/vibe/wire_gen.go
@@ -31,11 +31,14 @@ func BuildOutPipeline(root string, args OutCmd) (*OutPipeline, error) {
 	fileMapWriter := ProvideFileMapService(root, outputMetrics)
 	contentLoader := ProvideContentLoader()
 	outPipeline := &OutPipeline{
-		DT:       directoryTree,
-		Renderer: renderer,
-		FileMap:  fileMapWriter,
-		Metrics:  outputMetrics,
-		Loader:   contentLoader,
+		DT:           directoryTree,
+		Renderer:     renderer,
+		FileMap:      fileMapWriter,
+		Metrics:      outputMetrics,
+		Loader:       contentLoader,
+		Template:     nil,
+		ContentSpecs: nil,
+		DataPairs:    nil,
 	}
 	return outPipeline, nil
 }


### PR DESCRIPTION
## Summary
- remove `OutArgs` transport struct
- move layout and select overrides into `overrideTemplate`
- store template and input params directly on `OutPipeline`
- simplify `OutPipeline.Run`

## Testing
- `go test ./...`
