### PR TITLE
Introduce AppEnv struct for DI

### DIFF
--- a/cmd/vibe/out.go
+++ b/cmd/vibe/out.go
@@ -126,7 +126,6 @@ func (r *OutRunner) Run() error {
 	}
 	pipe.Template = tmpl
 	pipe.ContentSpecs = r.Args.Content
-	pipe.DataPairs = r.Args.Data
 
 	if err := pipe.Run(dest); err != nil {
 		return err

--- a/cmd/vibe/out_pipeline.go
+++ b/cmd/vibe/out_pipeline.go
@@ -13,16 +13,15 @@ import (
 
 // OutPipeline groups all services needed by the out command.
 type OutPipeline struct {
-	DT               *DirectoryTree
-	Renderer         *render.Renderer
-	FileMap          *FileMapWriter
-	Metrics          *metrics.OutputMetrics
-	Loader           ContentLoader
-	WorkingDirectory string
+	DT       *DirectoryTree
+	Renderer *render.Renderer
+	FileMap  *FileMapWriter
+	Metrics  *metrics.OutputMetrics
+	Loader   ContentLoader
+	Env      *AppEnv
 
 	Template     *render.Template
 	ContentSpecs []string
-	DataPairs    []string
 }
 
 // outData implements render.Content and exposes helpers for templates.
@@ -87,7 +86,7 @@ func (d *outData) RepoPrompts() (string, error) {
 
 // Run executes the rendering pipeline using args for configuration.
 func (p *OutPipeline) Run(out io.Writer) error {
-	dataMap, err := parseDataParams(p.DataPairs)
+	dataMap, err := parseDataParams(p.Env.DataPairs)
 	if err != nil {
 		return err
 	}
@@ -116,7 +115,7 @@ func (p *OutPipeline) Run(out io.Writer) error {
 		selectPattern:    selectPattern,
 		dirTreePattern:   dirTreePattern,
 		rootPath:         root,
-		WorkingDirectory: p.WorkingDirectory,
+		WorkingDirectory: string(p.Env.WorkingDirectory),
 		ContentStr:       content,
 		Data:             dataMap,
 	}

--- a/cmd/vibe/wire.go
+++ b/cmd/vibe/wire.go
@@ -8,6 +8,7 @@ import (
 
 func BuildOutPipeline(root string, args OutCmd) (*OutPipeline, error) {
 	wire.Build(
+		ProvideAppEnv,
 		ProvideCounter,
 		ProvideMetrics,
 		ProvideFSList,
@@ -15,9 +16,8 @@ func BuildOutPipeline(root string, args OutCmd) (*OutPipeline, error) {
 		ProvideRenderer,
 		ProvideDirectoryTreeService,
 		ProvideFileMapService,
-		ProvideWorkingDirectory,
 		ProvideContentLoader,
-		wire.Struct(new(OutPipeline), "DT", "Renderer", "FileMap", "Metrics", "Loader", "WorkingDirectory"),
+		wire.Struct(new(OutPipeline), "DT", "Renderer", "FileMap", "Metrics", "Loader", "Env"),
 	)
 	return nil, nil
 }

--- a/cmd/vibe/wire_gen.go
+++ b/cmd/vibe/wire_gen.go
@@ -13,11 +13,15 @@ import (
 // Injectors from wire.go:
 
 func BuildOutPipeline(root string, args OutCmd) (*OutPipeline, error) {
-	directoryTree, err := ProvideDirectoryTreeService(root)
+	appEnv, err := ProvideAppEnv(root, args)
 	if err != nil {
 		return nil, err
 	}
-	v, err := ProvideFSList(root)
+	directoryTree, err := ProvideDirectoryTreeService(appEnv)
+	if err != nil {
+		return nil, err
+	}
+	v, err := ProvideFSList(appEnv)
 	if err != nil {
 		return nil, err
 	}
@@ -28,19 +32,15 @@ func BuildOutPipeline(root string, args OutCmd) (*OutPipeline, error) {
 	}
 	outputMetrics := ProvideMetrics(counter)
 	renderer := ProvideRenderer(resolver, outputMetrics)
-	fileMapWriter := ProvideFileMapService(root, outputMetrics)
-	workingDirectory := ProvideWorkingDirectory(root)
+	fileMapWriter := ProvideFileMapService(appEnv, outputMetrics)
 	contentLoader := ProvideContentLoader()
 	outPipeline := &OutPipeline{
-		DT:               directoryTree,
-		Renderer:         renderer,
-		FileMap:          fileMapWriter,
-		Metrics:          outputMetrics,
-		Loader:           contentLoader,
-		WorkingDirectory: workingDirectory,
-		Template:         nil,
-		ContentSpecs:     nil,
-		DataPairs:        nil,
+		DT:       directoryTree,
+		Renderer: renderer,
+		FileMap:  fileMapWriter,
+		Metrics:  outputMetrics,
+		Loader:   contentLoader,
+		Env:      appEnv,
 	}
 	return outPipeline, nil
 }


### PR DESCRIPTION
## Summary
- collect runtime environment values in `AppEnv`
- inject `AppEnv` into providers instead of raw strings
- update `OutPipeline` to hold `AppEnv`
- regenerate DI with wire

## Testing
- `go test ./...`
